### PR TITLE
avoiding QTextCursor warking messages.

### DIFF
--- a/Python-Robocode/GUI/Ui_RobotInfo.py
+++ b/Python-Robocode/GUI/Ui_RobotInfo.py
@@ -99,5 +99,5 @@ if __name__ == "__main__":
     ui = Ui_Form()
     ui.setupUi(Form)
     Form.show()
-    sys.exit(app.exec_())
+    sys.exit(app.exec())
 

--- a/Python-Robocode/GUI/Ui_battle.py
+++ b/Python-Robocode/GUI/Ui_battle.py
@@ -188,5 +188,5 @@ if __name__ == "__main__":
     ui = Ui_Dialog()
     ui.setupUi(Dialog)
     Dialog.show()
-    sys.exit(app.exec_())
+    sys.exit(app.exec())
 

--- a/Python-Robocode/GUI/Ui_outPrint.py
+++ b/Python-Robocode/GUI/Ui_outPrint.py
@@ -12,8 +12,9 @@
 
 from PyQt6.QtWidgets import QApplication, QWidget, QTextEdit
 from PyQt6.QtWidgets import QSizePolicy, QVBoxLayout, QHBoxLayout
-from PyQt6.QtGui import QIcon, QPixmap
+from PyQt6.QtGui import QIcon, QPixmap, QTextCursor
 from PyQt6.QtCore import QMetaObject
+
 
 class Ui_Form(object):
     def setupUi(self, Form):
@@ -24,9 +25,14 @@ class Ui_Form(object):
         Form.setWindowIcon(icon)
         self.verticalLayout = QVBoxLayout(Form)
         self.verticalLayout.setObjectName("verticalLayout")
+
         self.textEdit = QTextEdit(Form)
         self.textEdit.setObjectName("textEdit")
+        self.textEdit.setPlainText("     ")
+        self.textCursor = QTextCursor(self.textEdit.document())
         self.verticalLayout.addWidget(self.textEdit)
+
+        self.isTextEmpty = True
 
         self.retranslateUi(Form)
         QMetaObject.connectSlotsByName(Form)
@@ -37,10 +43,10 @@ class Ui_Form(object):
 
 if __name__ == "__main__":
     import sys
+
     app = QApplication(sys.argv)
     Form = QWidget()
     ui = Ui_Form()
     ui.setupUi(Form)
     Form.show()
-    sys.exit(app.exec_())
-
+    sys.exit(app.exec())

--- a/Python-Robocode/GUI/Ui_window.py
+++ b/Python-Robocode/GUI/Ui_window.py
@@ -184,5 +184,5 @@ if __name__ == "__main__":
     ui = Ui_MainWindow()
     ui.setupUi(MainWindow)
     MainWindow.show()
-    sys.exit(app.exec_())
+    sys.exit(app.exec())
 

--- a/Python-Robocode/GUI/outPrint.py
+++ b/Python-Robocode/GUI/outPrint.py
@@ -5,6 +5,7 @@ Module implementing outPrint.
 """
 
 from PyQt6.QtWidgets import QWidget
+from PyQt6.QtGui import QTextCursor
 
 from Ui_outPrint import Ui_Form
 
@@ -21,4 +22,9 @@ class outPrint(QWidget, Ui_Form):
 
         
     def add(self, msg):
-        self.textEdit.append(msg)
+        if self.isTextEmpty:
+            self.textEdit.setPlainText(msg)
+            self.isTextEmtpy = False
+        else:
+            self.textCursor.movePosition(QTextCursor.MoveOperation.End)
+            self.textCursor.insertText("\n" + msg)


### PR DESCRIPTION
A quick hack to suppress the warning message "QTextCursor::setPosition: Position '1' out of range".